### PR TITLE
expand wording, including categories of discrimination

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 Data Science Minneapolis is dedicated to providing an inclusive and supportive environment for everyone. We ask that all members respect each other. We aim to create a culture that is collaborative, inclusive, and empowering. This community should be free of harrassment, bias, and discrimination. We do not tolerate harassment in any form. Members violating these rules may be sanctioned or expelled from events or activities at the discretion of the organizers.
 
-Harassment includes offensive verbal comments related to gender, sexual orientation, disability, appearance, race, religion, sexual images in public spaces, intimidation, stalking, harassing photography or recordings, malicious disruption of talks or other events, inappropriate physical contact, and unwelcome sexual attention. Participants asked to stop any harassing behavior are expected to comply immediately.
+Harassment includes: offensive verbal or written comments related to age, appearance, disability, family status, gender or gender idendity, nationality, race, religion or belief, or sexual orientation; sexual images in public spaces; intimidation; stalking; harassing photography or recordings; malicious disruption of talks or other events; inappropriate physical contact and unwelcome sexual attention; and any other inappropriate behavior. Participants asked to stop any harassing behavior are expected to comply immediately.
 
 If a member engages in harassing behavior, the organizers may take any action they deem appropriate, including warning the offender or expulsion from any event or online platform. If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact an organizer immediately.
 
-Organizers will be happy to help participants contact security or local law enforcement, provide escorts, or otherwise assist those experiencing harassment to feel safe.
+Organizers will be happy to help participants contact security or local law enforcement, accompany participants in traveling to/from events, or otherwise assist those experiencing harassment to feel safe.
 
-This code of conduct applies to all venues and events, online and offline. Including, but not limited to, meetups, Twitter, Slack, Instagram, and Facebook.
+This code of conduct applies to all venues and events, online and offline. This includes, but is not limited to, meetups, Twitter, Slack, Instagram, and Facebook.
 
-Feel free to contact us at: minneapolisds@gmail.com
+Feel free to contact us at minneapolisds@gmail.com.


### PR DESCRIPTION
I really like the [ACM Code of Ethics and Professional Conduct](https://www.acm.org/code-of-ethics). I'm a member, and loosely based a portion of these changes on some of their wording.

I debated adding language around respecting individuals' [preferred gender pronouns](https://en.wikipedia.org/wiki/Preferred_gender_pronoun) (see [reference 1](https://www.mypronouns.org/what-and-why) and [reference 2](https://lgbt.ucsf.edu/pronounsmatter)), but for now I think the "We ask that all members respect each other." line would include the implied "respect someone's wishes for how you should refer to them" (as things like nicknames also are a part of this).